### PR TITLE
Record and retrieve solutions correctly.

### DIFF
--- a/codeoil.js
+++ b/codeoil.js
@@ -144,9 +144,17 @@ router.post('/attempt', function () {
 });
 
 router.get('/', function* (next) {
-    yield this.render('index', {
-        authenticated: this.isAuthenticated() ? this.req.user : null,
-    })
+    if (this.isAuthenticated()) {
+        operations.LoadQuestionStatuses(this.req.user).then(function (user) {
+             yield this.render('index', {
+                authenticated: user,
+            })
+        });
+    } else {
+        yield this.render('index', {
+            authenticated: null,
+        });
+    }
 });
 
 // Attach router as middleware.

--- a/codeoil.js
+++ b/codeoil.js
@@ -1,4 +1,5 @@
 /* jslint node: true, esnext: true */
+'use strict'
 var process = require('process');
 var koa = require('koa');
 var body = require('koa-body');
@@ -61,10 +62,10 @@ app.use(handlebars({
         'challengeClass': function (user, challengeId) {
             if (user === null) return 'unfinished';
 
-            var solved = user.challenges.find( 
+            var solved = user.challenges.find(
                 (challenge) => challenge.challengeId === challengeId && challenge.status == 'SOLVED'
             );
-            
+
             return (solved !== undefined) ? 'finished' : 'unfinished';
         },
     },
@@ -117,7 +118,7 @@ router.get('/success', function () {
     this.redirect('/');
 })
 
-router.get('/logout', function (ctx) {
+router.get('/logout', function () {
     this.logout();
     this.redirect('/');
 });
@@ -143,18 +144,15 @@ router.post('/attempt', function () {
     }
 });
 
-router.get('/', function* (next) {
+router.get('/', function* () {
+    let user = null;
     if (this.isAuthenticated()) {
-        operations.LoadQuestionStatuses(this.req.user).then(function (user) {
-             yield this.render('index', {
-                authenticated: user,
-            })
-        });
-    } else {
-        yield this.render('index', {
-            authenticated: null,
-        });
+        user = yield operations.LoadQuestionStatuses(this.req.user); //.then(function (user) {
     }
+    
+    yield this.render('index', {
+        authenticated: user,
+    });
 });
 
 // Attach router as middleware.

--- a/codeoil.js
+++ b/codeoil.js
@@ -128,10 +128,11 @@ router.get('/logout', function (ctx) {
  */
 router.post('/attempt', function () {
     try {
+        if (!this.isAuthenticated()) throw Exception('You must be logged in to submit an attempt.');
         var request = JSON.parse(this.request.body);
 
         if (request.attempt && request.hash) {
-            operations.LogAttempt(request.attempt, request.hash);
+            operations.LogAttempt(this.req.user, request.attempt, request.hash);
             this.response.status = 200;
         } else {
             this.response.status = 422;

--- a/db/models.js
+++ b/db/models.js
@@ -32,7 +32,7 @@ module.exports = (function () {
     };
 
     // Add a key connecting the solution to the model that first solved it
-    models.Solution.belongsTo(models.Attempt, { as: 'attemptId' });
+    models.Solution.belongsTo(models.Attempt, { as: 'correctAttempt' });
     models.Solution.belongsTo(models.User, { as: 'solvedBy' });
     models.Status.belongsTo(models.User, { as: 'user' });
 

--- a/db/operations.js
+++ b/db/operations.js
@@ -102,6 +102,7 @@ module.exports = {
                     Models.Status.create({
                         challengeId: solution.challengeId,
                         status: 'SOLVED',
+                        user: user,
                     });
                 }
             });
@@ -118,10 +119,12 @@ module.exports = {
             },
         }), function () { });
     },
-    RegisterSolution: function (attempt, hash) {
+    RegisterSolution: function (payload, hash) {
         return Models.Solution.create({
-            attempt: attempt,
-            hash: hash
+            attempt: payload.attempt,
+            hash: hash,
+            seed: payload.seed,
+            challengeId: payload.challenge,
         });
     },
 };

--- a/db/operations.js
+++ b/db/operations.js
@@ -76,6 +76,9 @@ module.exports = {
         //
         // This is all async; the /attempt endpoint does not return a meaningful value but
         // will update the user's profile asynchronously.
+        //
+        // Note to future self: this logic assumes that the solution from the task runners will
+        // be available prior to the user's guess. This should be fine but worth noting...
         return Models.Solution.findOne({
             where: {
                 attempt: attemptId,
@@ -91,7 +94,10 @@ module.exports = {
             }).then(function (attempt) {
                 // Update this value if it's currently unset and the current attempt was correct.
                 // This means that SolvedById will be set to the *first* Attempt that solved it.
-                if (attempt.correct && solution.solvedById === null) solution.setSolvedBy(attempt);
+                if (attempt.correct && solution.solvedById === null) {
+                    solution.setSolvedBy(attempt);
+                    solution.save();
+                }
             });
         });
     },

--- a/db/operations.js
+++ b/db/operations.js
@@ -32,6 +32,7 @@ module.exports = {
                     plain: true,
                 });
 
+                // Same as LoadQuestionStatuses below.
                 return Models.Status.findAll({
                     where: {
                         UserId: user.id,
@@ -69,6 +70,17 @@ module.exports = {
             else return CreateUser();
         });
     },
+    // Get the latest player status for each question.
+    LoadQuestionStatuses: function (user) {
+        return Models.Status.findAll({
+            where: {
+                UserId: user.id,
+            }
+        }).then(function (challenges) {
+            user.challenges = challenges.map((challenge) => challenge.get({ plain: true }));
+            return user;
+        })
+    },
     LogAttempt: function (user, attemptId, hash) {
         // Check to see if this is a correct solution. Afterwards, insert the Attempt into
         // a separate table and provide a link from Solution => Attempt if this does indeed
@@ -96,13 +108,13 @@ module.exports = {
                 // This means that SolvedById will be set to the *first* Attempt that solved it.
                 if (attempt.correct && solution.solvedById === null) {
                     solution.setCorrectAttempt(attempt);
-                    solution.setSolvedBy(user);
-                    
+                    // TODO: set SolvedBy field (currently giving me annoying error...)
+
                     // Create a new record in the status table.
                     Models.Status.create({
                         challengeId: solution.challengeId,
                         status: 'SOLVED',
-                        user: user,
+                        userId: user.id,
                     });
                 }
             });

--- a/db/operations.js
+++ b/db/operations.js
@@ -69,7 +69,7 @@ module.exports = {
             else return CreateUser();
         });
     },
-    LogAttempt: function (attemptId, hash) {
+    LogAttempt: function (user, attemptId, hash) {
         // Check to see if this is a correct solution. Afterwards, insert the Attempt into
         // a separate table and provide a link from Solution => Attempt if this does indeed
         // provide a valid solution.
@@ -95,8 +95,14 @@ module.exports = {
                 // Update this value if it's currently unset and the current attempt was correct.
                 // This means that SolvedById will be set to the *first* Attempt that solved it.
                 if (attempt.correct && solution.solvedById === null) {
-                    solution.setSolvedBy(attempt);
-                    solution.save();
+                    solution.setCorrectAttempt(attempt);
+                    solution.setSolvedBy(user);
+                    
+                    // Create a new record in the status table.
+                    Models.Status.create({
+                        challengeId: solution.challengeId,
+                        status: 'SOLVED',
+                    });
                 }
             });
         });

--- a/runner/runner.js
+++ b/runner/runner.js
@@ -30,11 +30,11 @@ SolutionHandler.prototype.work = function (payload, callback) {
             return param.next();
         });
 
-        console.log(params, solution.solver.apply(null, params));
+        // console.log(params, solution.solver.apply(null, params));
         agg.add(solution.solver.apply(null, params));
     }
 
-    operations.RegisterSolution(payload.attempt, agg.token());
+    operations.RegisterSolution(payload, agg.token());
     callback('success');
 }
 


### PR DESCRIPTION
This PR fixed a few spurious bugs related to how attempts and solutions are recorded and also makes it so that statuses are updated when users guess correctly.
- Attempts are logged, and solutions have a reference back to the attempt that solved it.
- Workers are now recording complete solution records (several fields were missing before).
- Question statuses are loaded on the `/` route when users are logged in.
